### PR TITLE
Nav: cross-link to rapp_store for bundled rapplications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **[Install Brainstem](https://github.com/kody-w/rapp-installer)** | **[Try vSandbox](https://kody-w.github.io/RAR/virtual-brainstem.html)** | **[Agent Store](https://kody-w.github.io/RAR/)** | **[Binder](https://kody-w.github.io/RAR/binder.html)** | **[FAQ](https://kody-w.github.io/RAR/faq.html)** | **[Whitepaper](https://kody-w.github.io/RAR/whitepaper.html)**
 
+> **Need a bundled rapplication** (agent + UI / service / state) **rather than a single file?** Browse **[kody-w/RAPP_Store](https://kody-w.github.io/RAPP_Store/)** — the catalog of packaged rapplications. Per [Constitution Article XXVII](https://github.com/kody-w/RAPP/blob/main/CONSTITUTION.md#article-xxvii--rar-holds-files-the-rapp-store-holds-bundles): bare agents live here in RAR; bundles live in the rapp store.
+
 ---
 
 ## Submit an Agent (one command)


### PR DESCRIPTION
Pure additive doc change — surfaces the rapp_store/RAR boundary on this repo's README.

## What changes

Adds a one-line callout under the existing top nav row:

> **Need a bundled rapplication** (agent + UI / service / state) **rather than a single file?** Browse **[kody-w/RAPP_Store](https://kody-w.github.io/RAPP_Store/)**...

Plus a reference to [Constitution Article XXVII](https://github.com/kody-w/RAPP/blob/main/CONSTITUTION.md#article-xxvii--rar-holds-files-the-rapp-store-holds-bundles).

## Why

A visitor landing on RAR currently has no cue that bundled rapplications (agents paired with UIs, services, or state cartridges) live in a separate catalog. This makes the constitutional boundary visible without adding a single line of code.

## Companion

Reverse link is being added in [kody-w/RAPP_Store](https://github.com/kody-w/RAPP_Store/pulls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)