### PR TITLE
Fix approve-agent.yml: forge cards after build_registry, then rebuild

### DIFF
--- a/.github/workflows/approve-agent.yml
+++ b/.github/workflows/approve-agent.yml
@@ -85,13 +85,20 @@ jobs:
           print(f'Total promoted: {len(promoted)}')
           "
 
+      # Build registry FIRST so the card forge sees the just-promoted agent.
+      # generate_holo_cards.py iterates over registry.json — running it before
+      # build_registry.py leaves new agents un-forged (_has_card: false).
+      - name: Build registry (pre-forge — surfaces the promoted agent)
+        run: python build_registry.py
+
       - name: Forge cards for approved agents
         run: |
           if [ -f /tmp/promoted.txt ]; then
             python scripts/generate_holo_cards.py
           fi
 
-      - name: Build registry
+      # Rebuild so build_registry.py's _has_card check picks up the new card.
+      - name: Build registry (post-forge — flips _has_card)
         run: python build_registry.py
 
       - name: Commit approved agents


### PR DESCRIPTION
## Summary
- `generate_holo_cards.py` reads `registry.json` to know which agents need cards
- The current step order in `approve-agent.yml` runs the forge **before** `build_registry.py`, so on a fresh approval the registry doesn't yet contain the just-promoted agent — the forge silently skips it
- Result: every brand-new agent submission lands with `_has_card: false` on first run
- Fix reorders to: **build registry → forge → rebuild registry**. The first build surfaces the promoted agent for the forge; the second flips `_has_card` now that `cards/holo_cards.json` contains the new entry

## Repro
Most recent example: issue #64 (`@rapp/rapplication_agent`) approved cleanly but landed with `_has_card: false` until manually patched in `f6d0e55`.

## Test plan
- [ ] Submit a fresh `[AGENT] @ns/slug` Issue against a test branch with this fix applied
- [ ] Approve the Issue and watch the workflow run all three build/forge/rebuild steps
- [ ] Verify `registry.json` shows `_has_card: true` and `cards/holo_cards.json` contains the new key in a single workflow run (no manual patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)