### PR TITLE
Add @rapp/hacker_news + @kody/workiq

### DIFF
--- a/agents/@kody/workiq_agent.py
+++ b/agents/@kody/workiq_agent.py
@@ -1,0 +1,248 @@
+"""
+WorkIQ Agent - Microsoft 365 Data Access via work-iq-mcp
+
+This agent provides natural language access to Microsoft 365 data including:
+- Emails and conversations
+- Calendar meetings and events
+- Documents (SharePoint, OneDrive)
+- Teams messages and channels
+- People and organizational contacts
+
+Prerequisites:
+    1. Install workiq CLI: npm install -g @microsoft/workiq
+    2. Accept EULA: workiq accept-eula
+    3. Authenticate: Run workiq ask once to complete Entra ID login
+
+Usage:
+    The agent accepts natural language queries about M365 data.
+    Examples:
+    - "What emails did I receive from my manager this week?"
+    - "What meetings do I have tomorrow?"
+    - "Find documents about project planning"
+    - "What did Sarah say in Teams about the deadline?"
+"""
+
+import logging
+import os
+import re
+import subprocess
+import shutil
+import json
+from agents.basic_agent import BasicAgent
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@kody/workiq",
+    "version": "1.0.0",
+    "display_name": "WorkIQ",
+    "description": "Natural-language access to Microsoft 365 data — emails, calendar, SharePoint/OneDrive, Teams messages, people. Wraps the workiq CLI (Entra ID auth required).",
+    "author": "Kody",
+    "tags": ["m365", "microsoft", "email", "calendar", "teams", "sharepoint", "workiq"],
+    "category": "integrations",
+    "quality_tier": "community",
+    "requires_env": [],
+    "dependencies": ["@rapp/basic_agent"],
+    "external_prereqs": [
+        "npm install -g @microsoft/workiq",
+        "workiq accept-eula",
+        "Entra ID login (run `workiq ask` once)",
+    ],
+    "example_call": "What emails did I receive from my manager this week?",
+}
+
+
+
+_ANSI_RE = re.compile(r'\x1b(?:\[[0-9;?]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\))')
+
+
+def _strip_ansi(text):
+    return _ANSI_RE.sub('', text or '')
+
+
+class WorkIQAgent(BasicAgent):
+    def __init__(self):
+        self.name = 'WorkIQ'
+        self.metadata = {
+            "name": self.name,
+            "description": (
+                "Access Microsoft 365 data using natural language queries. "
+                "Can search emails, calendar meetings, documents, Teams messages, and people information. "
+                "Use this agent when the user wants to find or retrieve information from their Microsoft 365 tenant."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "The natural language query to search Microsoft 365 data. "
+                            "Examples: 'What emails did I receive from John this week?', "
+                            "'What meetings do I have tomorrow?', "
+                            "'Find documents about the Q4 budget', "
+                            "'What did the team say about the deadline in Teams?'"
+                        )
+                    },
+                    "tenant_id": {
+                        "type": "string",
+                        "description": (
+                            "Optional Entra tenant ID for multi-tenant scenarios. "
+                            "Leave empty to use the default 'common' tenant."
+                        )
+                    },
+                    "data_type": {
+                        "type": "string",
+                        "enum": ["all", "email", "calendar", "documents", "teams", "people"],
+                        "description": (
+                            "Optional filter to search only specific data types. "
+                            "Default is 'all' which searches across all Microsoft 365 data."
+                        )
+                    }
+                },
+                "required": ["query"]
+            }
+        }
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        """Execute a WorkIQ query against Microsoft 365 data."""
+        query = kwargs.get('query', '')
+        tenant_id = kwargs.get('tenant_id', '')
+        data_type = kwargs.get('data_type', 'all')
+
+        if not query:
+            return "Error: No query provided. Please specify what information you want to find in Microsoft 365."
+
+        if not self._check_workiq_installed():
+            return self._get_installation_instructions()
+
+        enhanced_query = self._build_enhanced_query(query, data_type)
+        return self._execute_workiq_query(enhanced_query, tenant_id)
+
+    def _check_workiq_installed(self):
+        """Check if the workiq CLI is installed and available."""
+        import sys as _sys
+        if shutil.which('workiq'):
+            return True
+        if _sys.platform == 'win32':
+            appdata_cmd = os.path.join(os.path.expanduser("~"), "AppData", "Roaming", "npm", "workiq.CMD")
+            if os.path.isfile(appdata_cmd):
+                return True
+        if shutil.which('npx'):
+            return True
+        return False
+
+    def _get_installation_instructions(self):
+        """Return instructions for installing workiq."""
+        return (
+            "**WorkIQ CLI not found.** To use this agent, please install the WorkIQ CLI:\n\n"
+            "**Option 1 - Global installation:**\n"
+            "```bash\n"
+            "npm install -g @microsoft/workiq\n"
+            "workiq accept-eula\n"
+            "```\n\n"
+            "**Option 2 - Use without installation (via npx):**\n"
+            "```bash\n"
+            "npx -y @microsoft/workiq accept-eula\n"
+            "```\n\n"
+            "After installation, run `workiq ask 'test query'` once to complete Entra ID authentication."
+        )
+
+    def _build_enhanced_query(self, query, data_type):
+        """Build an enhanced query with data type context."""
+        if data_type == 'all':
+            return query
+
+        context_hints = {
+            'email': f"In my emails: {query}",
+            'calendar': f"In my calendar/meetings: {query}",
+            'documents': f"In my documents (SharePoint/OneDrive): {query}",
+            'teams': f"In Teams messages: {query}",
+            'people': f"About people/contacts: {query}"
+        }
+
+        return context_hints.get(data_type, query)
+
+    def _execute_workiq_query(self, query, tenant_id=''):
+        """Execute a query using the workiq CLI."""
+        import sys as _sys
+        try:
+            workiq_path = shutil.which('workiq')
+            if not workiq_path and _sys.platform == 'win32':
+                appdata_cmd = os.path.join(os.path.expanduser("~"), "AppData", "Roaming", "npm", "workiq.CMD")
+                if os.path.isfile(appdata_cmd):
+                    workiq_path = appdata_cmd
+
+            if workiq_path:
+                cmd = [workiq_path, 'ask', '-q', query]
+            else:
+                cmd = ['npx', '-y', '@microsoft/workiq', 'ask', '-q', query]
+
+            if tenant_id:
+                cmd.extend(['--tenant-id', tenant_id])
+
+            logging.info(f"WorkIQ Agent executing query: {query[:100]}...")
+
+            use_shell = _sys.platform == 'win32'
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                shell=use_shell
+            )
+
+            if result.returncode != 0:
+                error_msg = result.stderr.strip() if result.stderr else "Unknown error"
+
+                if 'EULA' in error_msg or 'accept-eula' in error_msg.lower():
+                    return (
+                        "**EULA not accepted.** Please run the following command first:\n"
+                        "```bash\n"
+                        "workiq accept-eula\n"
+                        "```"
+                    )
+                elif 'login' in error_msg.lower() or 'auth' in error_msg.lower():
+                    return (
+                        "**Authentication required.** Please authenticate with Microsoft Entra ID:\n"
+                        "```bash\n"
+                        "workiq ask 'test'\n"
+                        "```\n"
+                        "This will open a browser window for authentication."
+                    )
+                else:
+                    logging.error(f"WorkIQ error: {error_msg}")
+                    return f"Error querying Microsoft 365: {error_msg}"
+
+            output = _strip_ansi(result.stdout).strip()
+
+            if not output:
+                return "No results found for your query. Try rephrasing or broadening your search."
+
+            return self._format_output(output)
+
+        except subprocess.TimeoutExpired:
+            logging.error("WorkIQ query timed out after 120 seconds")
+            return (
+                "The query timed out. This might happen if:\n"
+                "- The query is too broad (try being more specific)\n"
+                "- Network connectivity issues\n"
+                "- Microsoft 365 services are slow to respond\n\n"
+                "Please try a more specific query."
+            )
+        except FileNotFoundError:
+            return self._get_installation_instructions()
+        except Exception as e:
+            logging.error(f"WorkIQ Agent error: {str(e)}")
+            return f"Error executing WorkIQ query: {str(e)}"
+
+    def _format_output(self, output):
+        """Format the workiq output for better readability."""
+        if output.startswith('{') or output.startswith('['):
+            try:
+                data = json.loads(output)
+                return f"**Microsoft 365 Query Results:**\n\n```json\n{json.dumps(data, indent=2)}\n```"
+            except json.JSONDecodeError:
+                pass
+
+        return f"**Microsoft 365 Query Results:**\n\n{output}"

--- a/agents/@rapp/hacker_news_agent.py
+++ b/agents/@rapp/hacker_news_agent.py
@@ -1,0 +1,114 @@
+"""
+hacker_news_agent.py — top stories from Hacker News, via the public Firebase API.
+
+Mirrors the OG local brainstem's hacker_news_agent.py. No API key, no auth.
+In Pyodide we fall back to fetch() via JS interop because urllib/requests
+need the browser networking layer.
+"""
+
+import json
+from agents.basic_agent import BasicAgent
+
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@rapp/hacker_news",
+    "version": "1.0.0",
+    "display_name": "Hacker News",
+    "description": "Fetches the top N stories from Hacker News.",
+    "author": "RAPP",
+    "tags": ["starter", "news", "http"],
+    "category": "integrations",
+    "quality_tier": "official",
+    "requires_env": [],
+    # Quick-click prompt the brainstem uses when you tap this agent's card/pill.
+    "example_call": "What are the top 5 stories on Hacker News right now?",
+}
+
+
+_HN_TOP = "https://hacker-news.firebaseio.com/v0/topstories.json"
+_HN_ITEM = "https://hacker-news.firebaseio.com/v0/item/{}.json"
+
+
+def _fetch_json(url):
+    """GET a URL → dict. Tries Pyodide JS fetch first, falls back to urllib."""
+    try:
+        from pyodide.http import open_url  # type: ignore
+        return json.loads(open_url(url).read())
+    except Exception:
+        pass
+    try:
+        import urllib.request
+        with urllib.request.urlopen(url, timeout=10) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except Exception as e:
+        raise RuntimeError(f"fetch failed: {e}")
+
+
+class HackerNewsAgent(BasicAgent):
+    def __init__(self):
+        self.name = "HackerNews"
+        self.metadata = {
+            "name": self.name,
+            "description": (
+                "Fetches the current top stories from Hacker News. Returns title, "
+                "URL, score, and author for each. Use when the user asks what's "
+                "on Hacker News, what's trending in tech, or for news headlines."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "description": "How many top stories to return. Default 10, max 30.",
+                        "minimum": 1,
+                        "maximum": 30,
+                    },
+                },
+                "required": [],
+            },
+        }
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        count = max(1, min(30, int(kwargs.get("count", 10) or 10)))
+        try:
+            top_ids = _fetch_json(_HN_TOP)[:count]
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+        stories = []
+        for sid in top_ids:
+            try:
+                d = _fetch_json(_HN_ITEM.format(sid))
+                if not d:
+                    continue
+                stories.append({
+                    "id": sid,
+                    "title": d.get("title"),
+                    "url": d.get("url") or f"https://news.ycombinator.com/item?id={sid}",
+                    "score": d.get("score"),
+                    "author": d.get("by"),
+                    "comments": d.get("descendants", 0),
+                })
+            except Exception:
+                continue
+
+        # Markdown with proper [title](url) links + HN comments link.
+        # The LLM tends to copy this format verbatim; pre-linked here means
+        # the rendered chat bubble has clickable titles + comment threads.
+        summary_lines = []
+        for i, s in enumerate(stories):
+            comments_url = f"https://news.ycombinator.com/item?id={s['id']}"
+            summary_lines.append(
+                f"{i+1}. **[{s['title']}]({s['url']})** "
+                f"— {s.get('score', 0)} points, by {s.get('author', '?')} "
+                f"· [{s.get('comments', 0)} comments]({comments_url})"
+            )
+        return json.dumps({
+            "status": "success",
+            "stories": stories,
+            "summary": "Top Hacker News stories:\n\n" + "\n\n".join(summary_lines)
+                       + "\n\nWhen presenting these to the user, render the titles as clickable markdown links exactly as written above.",
+            "data_slush": {"count": len(stories), "top_url": stories[0]["url"] if stories else None},
+        })

--- a/registry.json
+++ b/registry.json
@@ -1,9 +1,9 @@
 {
   "schema": "rapp-registry/1.1",
   "version": "1.1.0",
-  "generated_at": "2026-04-28T21:57:38.330074+00:00",
+  "generated_at": "2026-05-02T18:13:56.249825+00:00",
   "stats": {
-    "total_agents": 278,
+    "total_agents": 280,
     "total_swarms": 82,
     "publishers": 10,
     "categories": 22,
@@ -4637,6 +4637,44 @@
     },
     {
       "schema": "rapp-agent/1.0",
+      "name": "@kody/workiq",
+      "version": "1.0.0",
+      "display_name": "WorkIQ",
+      "description": "Natural-language access to Microsoft 365 data \u2014 emails, calendar, SharePoint/OneDrive, Teams messages, people. Wraps the workiq CLI (Entra ID auth required).",
+      "author": "Kody",
+      "tags": [
+        "m365",
+        "microsoft",
+        "email",
+        "calendar",
+        "teams",
+        "sharepoint",
+        "workiq"
+      ],
+      "category": "integrations",
+      "quality_tier": "community",
+      "requires_env": [],
+      "dependencies": [
+        "@rapp/basic_agent"
+      ],
+      "external_prereqs": [
+        "npm install -g @microsoft/workiq",
+        "workiq accept-eula",
+        "Entra ID login (run `workiq ask` once)"
+      ],
+      "example_call": "What emails did I receive from my manager this week?",
+      "_file": "agents/@kody/workiq_agent.py",
+      "_sha256": "f52f3f6bb1a714375e4ad0ad083b725061e2150847fcce2da26d566235ccef1f",
+      "_seed": 11504693252822279853,
+      "_size_kb": 9.5,
+      "_lines": 249,
+      "_has_card": false,
+      "_added_at": null,
+      "_first_commit_sha": null,
+      "_latest_commit_sha": null
+    },
+    {
+      "schema": "rapp-agent/1.0",
       "name": "@kody-w/hello_world_agent",
       "version": "1.0.0",
       "display_name": "Hello World",
@@ -4734,7 +4772,7 @@
       "display_name": "CopilotStudioForge",
       "description": "Translate a RAPP swarm (singleton .py) into a validated Microsoft Copilot Studio YAML bundle. Native multi-agent CS solution, no cloud bridge.",
       "author": "RAPP",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "tags": [
         "meta",
         "copilot-studio",
@@ -4755,14 +4793,14 @@
       },
       "anchored_on": "https://github.com/microsoft/skills-for-copilot-studio",
       "_file": "agents/@rapp/copilot_studio_forge_agent.py",
-      "_sha256": "6a98073e0469ac6fa7a0ce7906650d283e6e7d3054d5d69e3a734b10b64121b2",
+      "_sha256": "c5aad52466df06e1ae329064d4252b6c474b88c97fcd0c53714252018c9dd79a",
       "_seed": 6041207226650733437,
-      "_size_kb": 43.8,
-      "_lines": 1010,
+      "_size_kb": 44.5,
+      "_lines": 1027,
       "_has_card": true,
       "_added_at": "2026-04-28T16:27:14-04:00",
       "_first_commit_sha": "6a3798346214837567a08619a026575a4198e448",
-      "_latest_commit_sha": "6a3798346214837567a08619a026575a4198e448",
+      "_latest_commit_sha": "a82c6ba64b0257f08b2628e15934a217209ee08d",
       "_card_sha256": "993a8390a15cf5f6db9b2c9657544317c22aa6088c5d19ffb55a890530c1aaed"
     },
     {
@@ -4839,6 +4877,32 @@
       "_first_commit_sha": "8893033dba286f7269a6e171f4729639fd15fa9b",
       "_latest_commit_sha": "8893033dba286f7269a6e171f4729639fd15fa9b",
       "_card_sha256": "bbb50180a4140e2d907e9ffcd24ed9b2bc1e431a68cef109d521c5f46131d7d7"
+    },
+    {
+      "schema": "rapp-agent/1.0",
+      "name": "@rapp/hacker_news",
+      "version": "1.0.0",
+      "display_name": "Hacker News",
+      "description": "Fetches the top N stories from Hacker News.",
+      "author": "RAPP",
+      "tags": [
+        "starter",
+        "news",
+        "http"
+      ],
+      "category": "integrations",
+      "quality_tier": "official",
+      "requires_env": [],
+      "example_call": "What are the top 5 stories on Hacker News right now?",
+      "_file": "agents/@rapp/hacker_news_agent.py",
+      "_sha256": "51dd9c04dd7eb5a0701c5008a3797945b6188eb39d7de93b2a0467e03e1049a2",
+      "_seed": 12872764946609739620,
+      "_size_kb": 4.2,
+      "_lines": 115,
+      "_has_card": false,
+      "_added_at": null,
+      "_first_commit_sha": null,
+      "_latest_commit_sha": null
     },
     {
       "schema": "rapp-agent/1.0",
@@ -5020,7 +5084,7 @@
       "_has_card": true,
       "_added_at": "2026-04-27T23:17:53Z",
       "_first_commit_sha": "e0f39cd415ef22807efe0748c20bb145098b2fb5",
-      "_latest_commit_sha": "778c9173337e99d4a44fb0f6ec6788c17f25e555",
+      "_latest_commit_sha": "fdd532eaa9d3195f8bb63ca6960344ffa91e8318",
       "_card_sha256": "b31d6e0b72e5387182822dd9be2c768cb96fc2d201b7ee65084d0cf52c304afa"
     },
     {


### PR DESCRIPTION
Two bare agents from the RAPP brainstem framework that weren't yet registered. `@rapp/hacker_news` (official, public HN API, no auth) and `@kody/workiq` (community, M365 via the workiq CLI). Registry rebuilt automatically — 278 → 280 entries.

Both are skinless single-celled organisms — the right fit for RAR rather than RAPP_Store, per the unification ratified in [Rapplications Are Organisms](https://github.com/kody-w/RAPP/blob/main/pages/vault/Architecture/Rapplications%20Are%20Organisms.md).