### PR TITLE
Fix two pre-existing build_registry.py validation errors

### DIFF
--- a/agents/@kody-w/bakeoff_factory_agent.py
+++ b/agents/@kody-w/bakeoff_factory_agent.py
@@ -785,7 +785,7 @@ class BakeoffFactoryAgent(BasicAgent):
                 pid_file.unlink(missing_ok=True)
         # Spawn a child python that loops calling _round
         runner_code = (
-            "import time, sys, json, urllib.request\n"
+            "import os, time, sys, json, datetime, urllib.request\n"
             f"from pathlib import Path\n"
             f"sys.path.insert(0, '{os.path.dirname(os.path.abspath(__file__))}')\n"
             "import bakeoff_factory_agent as bf\n"
@@ -794,14 +794,14 @@ class BakeoffFactoryAgent(BasicAgent):
             "agent = bf.BakeoffFactoryAgent()\n"
             "ws = bf._workspace(name)\n"
             "cfg = bf._load_json(bf._config_path(ws), {})\n"
-            "(ws/'pump.pid').write_text(str(__import__('os').getpid()))\n"
+            "(ws/'pump.pid').write_text(str(os.getpid()))\n"
             "(ws/'logs').mkdir(exist_ok=True)\n"
             "rounds = 0\n"
             "log = open(ws/'logs'/'pump.log', 'a')\n"
             "while True:\n"
             "    try:\n"
             "        r = agent._round(name=name)\n"
-            "        log.write(f'[{__import__(\"datetime\").datetime.utcnow().isoformat()}Z] {r}\\n')\n"
+            "        log.write(f'[{datetime.datetime.utcnow().isoformat()}Z] {r}\\n')\n"
             "        log.flush()\n"
             "    except Exception as e:\n"
             "        log.write(f'ERR {e}\\n')\n"

--- a/agents/@rapp/rapp2mcs_factory_agent.py
+++ b/agents/@rapp/rapp2mcs_factory_agent.py
@@ -97,7 +97,7 @@ from pathlib import Path
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@rapp/rapp2mcs_factory",
-    "version": "0.3.0-singleton",
+    "version": "0.3.0",
     "display_name": "RAPP2MCS Factory",
     "description": (
         "End-to-end RAPP→MCS factory. Orchestrates AIBAST_RAPP/scripts "


### PR DESCRIPTION
## Summary

Unblocks CI on `main` (and on every open PR) by fixing two mechanical validator errors.  No behavior change.

| File | Error | Fix |
|------|-------|-----|
| `agents/@kody-w/bakeoff_factory_agent.py` | `__import__() is forbidden` | Replace `__import__('os').getpid()` / `__import__("datetime").datetime.utcnow()` inside a generated-code string with standard imports.  Same runtime behavior. |
| `agents/@rapp/rapp2mcs_factory_agent.py` | `Invalid version '0.3.0-singleton' — must be semver` | Bump to `0.3.0`.  The validator regex requires `X.Y.Z` all-digit; pre-release suffixes aren't accepted yet. |

## Local verification

```
$ python build_registry.py
✓ Registry built: 199 agents from 10 publishers
  (categories + publishers list unchanged)
  0 validation errors.
```

(Compare to current main: 2 validation errors blocking `build-registry` + `pipeline` jobs.)

## Why now

PR #98 (`@kody/twin_egg_hatcher` submission) cannot go green until these are cleared.  Last 3+ runs on main have failed for the same two reasons.

## Test plan

- [ ] CI `build-registry` passes
- [ ] CI `pipeline` passes
- [ ] PR #98 reruns and goes green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)