### PR TITLE
Mint the consolidated rappid form (stop emitting v2)

### DIFF
--- a/agents/@kody-w/ecosystem-grail-stack/plant_seed_agent.py
+++ b/agents/@kody-w/ecosystem-grail-stack/plant_seed_agent.py
@@ -33,6 +33,7 @@ clone locally. No follow-up commands required.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
 import subprocess
@@ -49,7 +50,7 @@ except ImportError:
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@kody-w/plant_seed_agent",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "display_name": "Plant Seed",
     "description": "Create a fresh public planted seed (neighborhood OR twin), grail-complete from minute one. Each planting includes the full front-door grail (rappid + soul + card.json (rappcards/1.1.2) + holo.svg + holo-qr.svg + holo.md + specs/ bundle + members + agents + .nojekyll + README + rar/). Default dry_run=True (shows the plan + file list); set dry_run=False to actually create.",
     "author": "kody-w",
@@ -103,7 +104,10 @@ def _now_iso() -> str:
 
 
 def _mint_rappid(kind: str, owner: str, name: str) -> str:
-    return f"rappid:v2:{kind}:@{owner}/{name}:{uuid.uuid4().hex}@github.com/{owner}/{name}"
+    # Consolidated rappid (CONSTITUTION Art. XXXIV.1, locked 2026-06-03):
+    # rappid:@<owner>/<slug>:<64hex> — self-locating + 256-bit identity. `kind`
+    # is written to the rappid.json record, not the string.
+    return f"rappid:@{owner}/{name}:{hashlib.sha256(uuid.uuid4().bytes).hexdigest()}"
 
 
 def _gh(args: list[str], timeout: int = 30) -> tuple[int, str, str]:

--- a/agents/@rapp/twin_agent.py
+++ b/agents/@rapp/twin_agent.py
@@ -53,7 +53,7 @@ from agents.basic_agent import BasicAgent
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@rapp/twin_agent",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "display_name": "Twin",
     "description": "Full digital-twin lifecycle and estate inspection in one cartridge: summon, hatch, boot, stop, list, inspect, browse eggs, soul history, lineage. Absorbs the prior Estate / Summon Twin / Hatch Egg cartridges.",
     "author": "RAPP",
@@ -79,7 +79,7 @@ KINDS = ("personal", "pre-founder", "memorial", "project", "place", "custom")
 # CONSTITUTION Article XXXIV.1 (2026-04-30 ratification). The legacy UUID
 # 37ad22f5-ed6d-48b1-b8b4-61019f58a42b is preserved as the hash field
 # (dashes stripped) — same identity, new string representation.
-WILDHAVEN_RAPPID = "rappid:v2:twin:@kody-w/wildhaven-ai-homes-twin:37ad22f5ed6d48b1b8b461019f58a42b@github.com/kody-w/wildhaven-ai-homes-twin"
+WILDHAVEN_RAPPID = "rappid:@kody-w/wildhaven-ai-homes-twin:37ad22f5ed6d48b1b8b461019f58a42b"
 WILDHAVEN_REPO = "https://github.com/kody-w/wildhaven-ai-homes-twin.git"
 
 PORT_LOW, PORT_HIGH = 7081, 7200
@@ -1078,10 +1078,11 @@ class TwinAgent(BasicAgent):
         if kind not in KINDS:
             return f"Error: unknown kind '{kind}'. Valid: {', '.join(KINDS)}"
 
-        # v2-format rappid per CONSTITUTION Article XXXIV.1. UUID hex (dashes
-        # stripped) lives in the hash field; same identity, v2 string shape.
-        _hash = uuid.uuid4().hex
-        rappid = f"rappid:v2:{kind}:@kody-w/{twin_name}:{_hash}@github.com/kody-w/{twin_name}"
+        # Consolidated rappid per CONSTITUTION Article XXXIV.1 (locked 2026-06-03):
+        # rappid:@<owner>/<slug>:<64hex> — self-locating + 256-bit identity hash.
+        # `kind` is written to the rappid.json record, not the string.
+        _hash = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+        rappid = f"rappid:@kody-w/{twin_name}:{_hash}"
         now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         # Workspace dir uses the hash (filesystem-friendly) — not the full v2 string.
         workspace = pathlib.Path(_twins_dir()) / _hash

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "schema": "rapp-registry/1.1",
   "version": "1.1.0",
-  "generated_at": "2026-05-25T02:27:41.828875+00:00",
+  "generated_at": "2026-06-03T19:54:55.967024+00:00",
   "stats": {
     "total_agents": 180,
     "total_swarms": 82,
@@ -4589,7 +4589,7 @@
     {
       "schema": "rapp-agent/1.0",
       "name": "@kody-w/plant_seed_agent",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "display_name": "Plant Seed",
       "description": "Create a fresh public planted seed (neighborhood OR twin), grail-complete from minute one. Each planting includes the full front-door grail (rappid + soul + card.json (rappcards/1.1.2) + holo.svg + holo-qr.svg + holo.md + specs/ bundle + members + agents + .nojekyll + README + rar/). Default dry_run=True (shows the plan + file list); set dry_run=False to actually create.",
       "author": "kody-w",
@@ -4609,10 +4609,10 @@
         "@rapp/basic_agent"
       ],
       "_file": "agents/@kody-w/ecosystem-grail-stack/plant_seed_agent.py",
-      "_sha256": "7739d2c2fa924624423cbdeedd4a8f439f0741dd3463ff85f1fd98e9da02ff11",
+      "_sha256": "4c69621f93f28ba9d71b9aff350a7f815a5623f397443a1d9c67ce3163dba6c7",
       "_seed": 344646004249601931,
-      "_size_kb": 26.0,
-      "_lines": 567,
+      "_size_kb": 26.3,
+      "_lines": 571,
       "_has_card": true,
       "_added_at": "2026-05-09T15:25:19-04:00",
       "_first_commit_sha": "74df455c5fc5eb8fb5ce77adefcb261763205866",
@@ -5844,7 +5844,7 @@
     {
       "schema": "rapp-agent/1.0",
       "name": "@rapp/twin_agent",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "display_name": "Twin",
       "description": "Full digital-twin lifecycle and estate inspection in one cartridge: summon, hatch, boot, stop, list, inspect, browse eggs, soul history, lineage. Absorbs the prior Estate / Summon Twin / Hatch Egg cartridges.",
       "author": "RAPP",
@@ -5865,10 +5865,10 @@
         "@rapp/basic_agent"
       ],
       "_file": "agents/@rapp/twin_agent.py",
-      "_sha256": "8bdf553457025f46ad8e6c3a5c9141823f8541731a868795d30e55700da58450",
+      "_sha256": "40e008117509434d46035b4f40d665cc2d4b406361c1e5aa86bc3cbc91a6b2d6",
       "_seed": 11907957554557236082,
       "_size_kb": 71.8,
-      "_lines": 1771,
+      "_lines": 1772,
       "_has_card": true,
       "_added_at": "2026-05-04T12:36:05-04:00",
       "_first_commit_sha": "7c5a0b0fea9bb1a0c1272fc1a23f0ef2ed49d521",


### PR DESCRIPTION
Updates RAR's 3 mint/const sites to emit the **consolidated** rappid `rappid:@<owner>/<slug>:<64hex>` (CONSTITUTION Art. XXXIV.1): `_mint_rappid` + `twin_agent` minting now produce the self-locating 256-bit form (kind → the record, not the string); `WILDHAVEN_RAPPID` canonicalized. Versions bumped (registry immutability) + `registry.json` rebuilt (180 agents). Legacy forms stay read-compatible. The 2 remaining test failures are pre-existing workflow-YAML checks (identical on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)