### PR TITLE
Consolidate rappid emit/parse to canonical rappid:@<owner>/<slug>:<64hex>

### DIFF
--- a/agents/@kody-w/twin_egg_hatcher_agent.py
+++ b/agents/@kody-w/twin_egg_hatcher_agent.py
@@ -73,7 +73,7 @@ from __future__ import annotations
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@kody-w/twin_egg_hatcher",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "HatchTwinEgg",
     "description": (
         "Generic single-file hatcher for any RAPP digital-organism twin. "
@@ -177,7 +177,12 @@ def _name_from_namespace(ns: str) -> Optional[str]:
 
 
 def _name_from_rappid(rappid: str) -> Optional[str]:
-    """Extract the slug from `rappid:v2:KIND:@owner/slug:HASH@...`."""
+    """Extract the slug from a rappid. Accepts the consolidated form
+    `rappid:@owner/slug:HEX64` and the legacy `rappid:v2:KIND:@owner/slug:HASH@...`."""
+    # Consolidated: no v<n>:kind: segment, slug runs up to the final ':<hex>'.
+    m = re.match(r"^rappid:@[^/]+/([^:]+):[a-f0-9]+$", rappid)
+    if m:
+        return m.group(1)
     m = re.match(r"^rappid:v\d+:[^:]+:@[^/]+/([^:]+):", rappid)
     return m.group(1) if m else None
 
@@ -195,13 +200,14 @@ def _resolve_name(rj: Dict[str, Any]) -> str:
 
 
 def _hash_from_rappid(rappid: str) -> str:
-    """Workspace dirname for a rappid.  Handles both:
+    """Workspace dirname for a rappid.  Handles:
+      - consolidated rappids (`rappid:@owner/slug:HEX64`, 256-bit)
       - v2 rappids (`rappid:v2:...:HEX32@...`)
       - bare-UUID rappids (legacy v1.x front doors like Heimdall)."""
     if rappid.startswith("rappid:"):
-        m = re.search(r":([a-f0-9]{32})@", rappid)
+        m = re.search(r":([a-f0-9]{64})$|:([a-f0-9]{32})@", rappid)
         if m:
-            return m.group(1)
+            return m.group(1) or m.group(2)
     return rappid
 
 

--- a/agents/@rapp/estate_outbound_agent.py
+++ b/agents/@rapp/estate_outbound_agent.py
@@ -49,7 +49,7 @@ except ImportError:
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@rapp/estate_outbound",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "EstateOutbound",
     "description": (
         "Stage a signed neighborhood event in the operator's outbound lane "
@@ -67,7 +67,7 @@ __manifest__ = {
     "dependencies": ["@rapp/basic_agent"],
     "example_call": {
         "args": {
-            "neighborhood_rappid": "rappid:v2:neighborhood:@rapp-commons/origin:3929ce90ebe97fe2a95432e9f647f3a3@github.com/kody-w/rapp-commons",
+            "neighborhood_rappid": "rappid:@rapp-commons/origin:3727bc584708e539d69792713fbb200688c634744cce2d9614fa5aefd4ff295f",
             "event": {"schema": "rapp-commons-event/1.0", "kind": "hello", "from": "...", "ts": "...", "body": "...", "sig": "...", "pub": {}}
         }
     },
@@ -114,7 +114,7 @@ class EstateOutboundAgent(BasicAgent):
                 "properties": {
                     "neighborhood_rappid": {
                         "type": "string",
-                        "description": "Target neighborhood's v2 rappid. Determines which subdir of ~/.brainstem/outbound/ receives the event.",
+                        "description": "Target neighborhood's rappid, consolidated form rappid:@<owner>/<slug>:<64hex>. Determines which subdir of ~/.brainstem/outbound/ receives the event.",
                     },
                     "event": {
                         "type": "object",

--- a/stacks/fleet-management/pack.json
+++ b/stacks/fleet-management/pack.json
@@ -12,8 +12,8 @@
     },
     "twin_egg_hatcher_agent.py": {
       "purpose": "Scale-aware single-file hatcher (agent / twin / neighborhood / swarm / factory / industry / estate eggs). Required on every peer mini Fleet talks to. Also useful locally for hatching .egg files from other operators.",
-      "size": 43827,
-      "sha256": "0df6f6eac947e10c9777b480ad98775081a6a85900775e2eae1fb3168214ba17"
+      "size": 44186,
+      "sha256": "7456fc537e8b525ae9108bec87deca67e29e21f730a7ce40f3a94a705d3600aa"
     }
   },
   "install": {

--- a/stacks/fleet-management/twin_egg_hatcher_agent.py
+++ b/stacks/fleet-management/twin_egg_hatcher_agent.py
@@ -73,7 +73,7 @@ from __future__ import annotations
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@kody-w/twin_egg_hatcher",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "HatchTwinEgg",
     "description": (
         "Generic single-file hatcher for any RAPP digital-organism twin. "
@@ -197,7 +197,12 @@ def _name_from_namespace(ns: str) -> Optional[str]:
 
 
 def _name_from_rappid(rappid: str) -> Optional[str]:
-    """Extract the slug from `rappid:v2:KIND:@owner/slug:HASH@...`."""
+    """Extract the slug from a rappid. Accepts the consolidated form
+    `rappid:@owner/slug:HEX64` and the legacy `rappid:v2:KIND:@owner/slug:HASH@...`."""
+    # Consolidated: no v<n>:kind: segment, slug runs up to the final ':<hex>'.
+    m = re.match(r"^rappid:@[^/]+/([^:]+):[a-f0-9]+$", rappid)
+    if m:
+        return m.group(1)
     m = re.match(r"^rappid:v\d+:[^:]+:@[^/]+/([^:]+):", rappid)
     return m.group(1) if m else None
 
@@ -215,13 +220,14 @@ def _resolve_name(rj: Dict[str, Any]) -> str:
 
 
 def _hash_from_rappid(rappid: str) -> str:
-    """Workspace dirname for a rappid.  Handles both:
+    """Workspace dirname for a rappid.  Handles:
+      - consolidated rappids (`rappid:@owner/slug:HEX64`, 256-bit)
       - v2 rappids (`rappid:v2:...:HEX32@...`)
       - bare-UUID rappids (legacy v1.x front doors like Heimdall)."""
     if rappid.startswith("rappid:"):
-        m = re.search(r":([a-f0-9]{32})@", rappid)
+        m = re.search(r":([a-f0-9]{64})$|:([a-f0-9]{32})@", rappid)
         if m:
-            return m.group(1)
+            return m.group(1) or m.group(2)
     return rappid
 
 

--- a/stacks/microsoft-365-team/factory_agent.py
+++ b/stacks/microsoft-365-team/factory_agent.py
@@ -291,9 +291,10 @@ class NeighborhoodFactoryAgent(BasicAgent):
             return json.dumps({"ok": False, "error": str(e)})
 
         # 2. Mint identifiers
-        nb_uuid = uuid.uuid4().hex
-        rappid = (f"rappid:v2:neighborhood:@{owner}/{nb_slug}:"
-                   f"{nb_uuid}@github.com/{owner}/{nb_slug}")
+        # Consolidated rappid: self-locating + 256-bit identity. The "neighborhood"
+        # kind lives in the rappid.json record, never in the string.
+        nb_digest = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+        rappid = f"rappid:@{owner}/{nb_slug}:{nb_digest}"
         rapp_uuid_dashboard = uuid.uuid4().hex
         plant_ts = _now_iso()
 

--- a/stacks/microsoft-365-team/pack.json
+++ b/stacks/microsoft-365-team/pack.json
@@ -7,8 +7,8 @@
   "files": {
     "factory_agent.py": {
       "purpose": "Drop into local brainstem agents/. Run NeighborhoodFactory to plant.",
-      "size": 16279,
-      "sha256": "8b8df0351b8e08bd044ec0ca467782152034688ca9526617294c01eda7ce6610"
+      "size": 16396,
+      "sha256": "79010b3038bca259d6e584da4e494eee71ae5b9f9140a1d8c470e6b0c36c6980"
     },
     "microsoft-365-team.egg": {
       "purpose": "Template content (11 agents). The factory pulls + customizes this at plant time.",

--- a/stacks/neighborhood-starter/factory_agent.py
+++ b/stacks/neighborhood-starter/factory_agent.py
@@ -291,9 +291,10 @@ class NeighborhoodFactoryAgent(BasicAgent):
             return json.dumps({"ok": False, "error": str(e)})
 
         # 2. Mint identifiers
-        nb_uuid = uuid.uuid4().hex
-        rappid = (f"rappid:v2:neighborhood:@{owner}/{nb_slug}:"
-                   f"{nb_uuid}@github.com/{owner}/{nb_slug}")
+        # Consolidated rappid: self-locating + 256-bit identity. The "neighborhood"
+        # kind lives in the rappid.json record, never in the string.
+        nb_digest = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+        rappid = f"rappid:@{owner}/{nb_slug}:{nb_digest}"
         rapp_uuid_dashboard = uuid.uuid4().hex
         plant_ts = _now_iso()
 

--- a/stacks/neighborhood-starter/pack.json
+++ b/stacks/neighborhood-starter/pack.json
@@ -8,8 +8,8 @@
   "files": {
     "factory_agent.py": {
       "purpose": "Drop into local brainstem agents/. Run NeighborhoodFactory to plant.",
-      "size": 16279,
-      "sha256": "8b8df0351b8e08bd044ec0ca467782152034688ca9526617294c01eda7ce6610"
+      "size": 16396,
+      "sha256": "79010b3038bca259d6e584da4e494eee71ae5b9f9140a1d8c470e6b0c36c6980"
     },
     "neighborhood-starter.egg": {
       "purpose": "Template content. The factory pulls + customizes this at plant time.",

--- a/staging/@kody-w/project_twin_agent.py
+++ b/staging/@kody-w/project_twin_agent.py
@@ -29,7 +29,7 @@ Spec conformance (sibling to twin_egg_hatcher_agent.py):
 __manifest__ = {
     "schema": "rapp-agent/1.0",
     "name": "@kody-w/project_twin_agent",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "display_name": "ProjectTwin",
     "description": (
         "Single-file lifecycle agent for project-anchored brainstem twins. "
@@ -53,6 +53,7 @@ __manifest__ = {
     "dependencies": ["@rapp/basic_agent"],
 }
 
+import hashlib
 import json
 import os
 import re
@@ -427,7 +428,9 @@ class ProjectWorkspaceAgent(BasicAgent):
 
 
 
-_HASH_RE = re.compile(r":([a-f0-9]{32})@")
+# Consolidated form: `rappid:@<owner>/<slug>:<64hex>` (256-bit, no trailing @suffix).
+# Legacy form (still read): `rappid:v2:<kind>:@<owner>/<slug>:<32hex>@github.com/...`.
+_HASH_RE = re.compile(r":([a-f0-9]{64})$|:([a-f0-9]{32})@")
 _AGENT_NAME_RE = re.compile(r"""self\.name\s*=\s*['"]([^'"]+)['"]""")
 _AGENT_DESC_RE = re.compile(r"""['"]description['"]\s*:\s*\(?\s*['"]([^'"]+)['"]""")
 
@@ -444,12 +447,15 @@ def _hash_from_rappid(rappid: str) -> str:
     if rappid and rappid.startswith("rappid:"):
         m = _HASH_RE.search(rappid)
         if m:
-            return m.group(1)
+            return m.group(1) or m.group(2)
     return rappid or ""
 
 
 def _mint_v2_rappid(kind: str, owner: str, repo: str) -> str:
-    return f"rappid:v2:{kind}:@{owner}/{repo}:{uuid.uuid4().hex}@github.com/{owner}/{repo}"
+    # Consolidated rappid: self-locating + 256-bit identity. `kind` lives in the
+    # rappid.json record, never in the string. (Param name kept for callers.)
+    digest = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+    return f"rappid:@{owner}/{repo}:{digest}"
 
 
 def _slug(s: str) -> str:


### PR DESCRIPTION
Moves all v2-rappid construction and format declaration in RAR to the consolidated canonical form **`rappid:@<owner>/<slug>:<64hex>`** (self-locating + 256-bit identity). Kind (project / neighborhood / agent) lives in the `rappid.json` record, never in the string. Parsers keep reading the legacy `rappid:v2:` forms.

## Emit / declare sites -> consolidated 256-bit form
- `staging/@kody-w/project_twin_agent.py` — `_mint_v2_rappid` now mints `hashlib.sha256(uuid.uuid4().bytes).hexdigest()`; added `import hashlib`.
- `stacks/neighborhood-starter/factory_agent.py` and `stacks/microsoft-365-team/factory_agent.py` — neighborhood rappid minted as the consolidated 256-bit form (`hashlib` already imported).
- `agents/@rapp/estate_outbound_agent.py` — `example_call` constant and the "v2 rappid" param description updated to the consolidated form.

## Parsers -> also accept consolidated, keep reading legacy
- `agents/@kody-w/twin_egg_hatcher_agent.py` and `stacks/fleet-management/twin_egg_hatcher_agent.py` — `_name_from_rappid` / `_hash_from_rappid` now match `rappid:@.../:HEX64` **and** the legacy `rappid:v2:...:HEX32@...`.
- `project_twin_agent.py` `_HASH_RE` handles `HEX64` (new) and `HEX32@` (legacy).

## Registry hygiene
- Version-immutability respected: bumped each changed published agent — `@rapp/estate_outbound` 1.0.0 -> 1.0.1, `@kody-w/twin_egg_hatcher` 1.0.0 -> 1.0.1, `@kody-w/project_twin_agent` 0.3.0 -> 0.3.1.
- `pack.json` size + sha256 refreshed for the edited stack files.
- `api/v1/` and `registry.json` are auto-built and intentionally **not** committed.

All touched `.py` pass `python3 -m py_compile`. Mint/parse verified round-trip for both consolidated and legacy forms. Diff scanned clean of secrets/tenant tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)